### PR TITLE
add install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,9 @@ You know how when you have bootstrap.hackreactor.com snapped to half of the scre
 Well, this simple chrome extension corrects that and makes the site more visually appealing.
 
 Because Bookstrap can be very slow to load, the reformatting function is called at a few different intervals.
+
+
+#### Install Instructions:
+1. Clone repo to local system.
+2. Ensure Chrome has [Developer Mode turned on](https://developer.chrome.com/extensions/faq#faq-dev-01).
+3. From chrome://Extensions, 'Load Unpacked Extension' and select folder from step 1.


### PR DESCRIPTION
Bookstrap's poor padding came up in our Sprint Reflection this morning, so I mentioned this extension. A lot of people seemed interested, but they might not know how to install the extension without these simple instructions.
